### PR TITLE
specify arch in install solana cache key

### DIFF
--- a/install-solana/action.yml
+++ b/install-solana/action.yml
@@ -19,7 +19,7 @@ runs:
       uses: buildjet/cache@v4
       with:
         path: ~/.local/share/solana/install/releases/${{ inputs.version }}
-        key: ${{ runner.os }}-solana-v${{ inputs.version }}
+        key: ${{ runner.os }}-${{ runner.arch }}-solana-v${{ inputs.version }}
 
     - name: Install Solana
       if: inputs.cache != 'true' || steps.cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
Allows differentiating caches between macos-arm and macos-x64.

![Selection_006](https://github.com/nifty-oss/actions/assets/1684605/7494cc4a-ff6c-4e16-a0eb-033a00a661c2)
![Selection_005](https://github.com/nifty-oss/actions/assets/1684605/2f7e00d7-3bfb-4c66-bd44-958590ef16c5)
